### PR TITLE
Update Janus instructions to use custom ~/.janus dir

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,9 +16,9 @@
 
 ## Installation for Janus Vim Distribution
 
-1. mkdir -p ~/.vim/janus/vim/tools/nerdtreetabs/plugin
+1. mkdir -p ~/.janus/nerdtreetabs/plugin
 
-2. curl https://raw.github.com/jistr/vim-nerdtree-tabs/master/nerdtree_plugin/vim-nerdtree-tabs.vim > ~/.vim/janus/vim/tools/nerdtreetabs/plugin/vim-nerdtree-tabs.vim
+2. curl https://raw.github.com/jistr/vim-nerdtree-tabs/master/nerdtree_plugin/vim-nerdtree-tabs.vim > ~/.janus/nerdtreetabs/plugin/vim-nerdtree-tabs.vim
 
 3. Celebrate.
 


### PR DESCRIPTION
Sorry, one change from the earlier pull request as I just realised this morning that janus provides this custom directory, so you don't have to add plugins to the core project installation.
