### PR TITLE
Added NERDTreeSteppedOpen/NERDTreeSteppedClose functions

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ Many of these features can be switched off. See section Configuration.
 
 ## Commands and Mappings
 
-Vim-nerdtree-tabs defines two commands:
+Vim-nerdtree-tabs defines four commands:
 
 * `:NERDTreeTabsToggle` switches NERDTree on/off for all tabs.
 
@@ -53,10 +53,17 @@ Vim-nerdtree-tabs defines two commands:
   perform a mirror of another tab's tree). If all this fails, a new tree is
   created. It is recommended that you use this command instead of `:NERDTreeToggle`.
 
+* `:NERDTreeSteppedOpen` focuses the NERDTree, opening one first if none is present.
+
+* `:NERDTreeSteppedClose` unfocuses the NERDTree, or closes/hides it if it was
+  not focused.
+
 There are also plug-mappings available with the same functionality:
 
 * `<plug>NERDTreeTabsToggle`
 * `<plug>NERDTreeMirrorToggle`
+* `<plug>NERDTreeSteppedOpen`
+* `<plug>NERDTreeSteppedClose`
 
 ## Configuration
 

--- a/nerdtree_plugin/vim-nerdtree-tabs.vim
+++ b/nerdtree_plugin/vim-nerdtree-tabs.vim
@@ -53,10 +53,14 @@ endif
 " === plugin mappings ===
 noremap <silent> <script> <Plug>NERDTreeTabsToggle :call <SID>NERDTreeToggleAllTabs()
 noremap <silent> <script> <Plug>NERDTreeMirrorToggle :call <SID>NERDTreeMirrorToggle()
+noremap <silent> <script> <Plug>NERDTreeSteppedOpen :call <SID>NERDTreeSteppedOpen()
+noremap <silent> <script> <Plug>NERDTreeSteppedClose :call <SID>NERDTreeSteppedClose()
 
 " === plugin commands ===
 command! NERDTreeTabsToggle call <SID>NERDTreeToggleAllTabs()
 command! NERDTreeMirrorToggle call <SID>NERDTreeMirrorToggle()
+command! NERDTreeSteppedOpen call <SID>NERDTreeSteppedOpen()
+command! NERDTreeSteppedClose call <SID>NERDTreeSteppedClose()
 
 
 " === initialization ===
@@ -221,6 +225,33 @@ endfun
 " returns 1 if current window is NERDTree, false otherwise
 fun! s:IsCurrentWindowNERDTree()
   return exists("t:NERDTreeBufName") && bufwinnr(t:NERDTreeBufName) == winnr()
+endfun
+
+" === Stepped Open/Close functions ===
+
+" focus the NERDTree view, creating one first if none is present
+fun! s:NERDTreeSteppedOpen()
+  if !s:IsCurrentWindowNERDTree()
+    if s:IsNERDTreeOpenInCurrentTab()
+      call s:NERDTreeFocus()
+    else
+      call s:NERDTreeMirrorOrCreate()
+    endif
+  endif
+endfun
+
+" unfocus the NERDTree view or closes it if it hadn't had focus at the time of
+" the call
+fun! s:NERDTreeSteppedClose()
+  if s:IsCurrentWindowNERDTree()
+    call s:NERDTreeUnfocus()
+  else
+    let l:nerdtree_open = s:IsNERDTreeOpenInCurrentTab()
+
+    if l:nerdtree_open
+      silent NERDTreeClose
+    endif
+  endif
 endfun
 
 " === NERDTree view manipulation (scroll and cursor positions) ===


### PR DESCRIPTION
I added two functions that I personally find useful and that might be of use to other people.

The need is explained in that [Stack Overflow question](http://stackoverflow.com/questions/11325044/how-to-customize-nerdtree-behavior) but basically is:
- `:NERDTreeSteppedOpen` focuses the NERDTree, opening one if none is present.
- `:NERDTreeSteppedClose` unfocuses the NERDTree if it has focus, or closes it otherwise.

Mapped respectively on `<C-Left>` and `<C-Right>`, it allows a natural open/close for NERDTree. Those mappings are obviously a suggestion and are **not** included in the pull-request.

I don't know if you like those functions, but I thought it might be interesting, hence the pull-request.

Whatever your decision, thanks for your work !
