### PR TITLE
Added missing exists() check

### DIFF
--- a/nerdtree_plugin/vim-nerdtree-tabs.vim
+++ b/nerdtree_plugin/vim-nerdtree-tabs.vim
@@ -196,7 +196,7 @@ endfun
 " restore focus to the window that was focused before leaving current tab
 fun! s:RestoreFocus()
   if g:nerdtree_tabs_synchronize_focus
-    if s:is_nerdtree_globally_focused
+    if exists("s:is_nerdtree_globally_focused") && s:is_nerdtree_globally_focused
       call s:NERDTreeFocus()
     elseif exists("t:NERDTreeTabLastWindow") && exists("t:NERDTreeBufName") && t:NERDTreeTabLastWindow != bufwinnr(t:NERDTreeBufName)
       exe t:NERDTreeTabLastWindow . "wincmd w"


### PR DESCRIPTION
In some cases, like loading back a session, the `s:is_nerdtree_globally_focused` variable is referenced without being defined.

I added an `exists()` check to prevent the error from occuring.
