### PR TITLE
Fix for $ vim <some-path-with a-space>

### DIFF
--- a/nerdtree_plugin/vim-nerdtree-tabs.vim
+++ b/nerdtree_plugin/vim-nerdtree-tabs.vim
@@ -376,7 +376,7 @@ endfun
 fun! s:VimEnterHandler()
   " if the argument to vim is a directory, cd into it
   if g:nerdtree_tabs_startup_cd && isdirectory(argv(0))
-    exe "cd " . argv(0)
+    exe 'cd "' . argv(0) . '"'
   endif
 
   let l:open_nerd_tree_on_startup = (g:nerdtree_tabs_open_on_console_startup && !has('gui_running')) ||


### PR DESCRIPTION
Starting vim with a file parameter with a space in the path causes the :cd command to think it is being given two parameters. Wrap it in double quotes.
