### PR TITLE
After getting NERDTree window, switch back to the previous window

### DIFF
--- a/nerdtree_plugin/vim-nerdtree-tabs.vim
+++ b/nerdtree_plugin/vim-nerdtree-tabs.vim
@@ -121,6 +121,13 @@ fun! s:NERDTreeMirrorOrCreate()
     if l:previous_winnr == winnr("$")
       silent NERDTreeToggle
     endif
+
+    " if the window count of current tab changed, it means that we have
+    " successfully getting a NERDTree window, we should move focus to the
+    " previous window
+    if l:previous_winnr != winnr("$")
+      wincmd p
+    endif
   endif
 endfun
 


### PR DESCRIPTION
If we use other plugins like MiniBufferExplorer which will open a plugin window too, switching to next window probably ended up in the MBE's plugin window, which is very likely to cause problems while swithing between tabs.
