### PR TITLE
Unfocus NERDTree window to next normal window

### DIFF
--- a/nerdtree_plugin/vim-nerdtree-tabs.vim
+++ b/nerdtree_plugin/vim-nerdtree-tabs.vim
@@ -187,7 +187,11 @@ fun! s:NERDTreeUnfocus()
   let t:NERDTreeTabLastWindow = winnr()
   if s:IsCurrentWindowNERDTree()
     let l:winNum = s:NextNormalWindow()
-    exec l:winNum.'wincmd w'
+    if l:winNum != -1
+      exec l:winNum.'wincmd w'
+    else
+      wincmd w
+    endif
   endif
 endfun
 


### PR DESCRIPTION
Avoid focusing to a plugin window like MiniBufExplorer, which would cause
unpredictable problems while switching between tabs.
