### PR TITLE
Show a file that is currently opened.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # vim-nerdtree-tabs changelog
 
+## v1.4.6
+
+* Add NERDTreeTabsFind function.
+
 ## v1.4.5
 
 * Add NERDTreeFocusToggle function. (Thanks orthez.)

--- a/README.md
+++ b/README.md
@@ -52,6 +52,8 @@ Vim-nerdtree-tabs provides these commands:
 
 * `:NERDTreeTabsToggle` toggles NERDTree on/off for all tabs.
 
+* `:NERDTreeTabsFind` find currently opened file and select it
+
 * `:NERDTreeMirrorOpen` acts as `:NERDTreeMirror`, but smarter: When opening,
   it first tries to use an existing tree (i.e. previously closed in this tab or
   perform a mirror of another tab's tree). If all this fails, a new tree is
@@ -74,6 +76,7 @@ There are also plug-mappings available with the same functionality:
 * `<plug>NERDTreeTabsOpen`
 * `<plug>NERDTreeTabsClose`
 * `<plug>NERDTreeTabsToggle`
+* `<plug>NERDTreeTabsFind`
 * `<plug>NERDTreeMirrorOpen`
 * `<plug>NERDTreeMirrorToggle`
 * `<plug>NERDTreeSteppedOpen`
@@ -85,45 +88,48 @@ You can switch on/off some features of the plugin by setting global vars to 1
 (for on) or 0 (for off) in your vimrc. Here are the options and their default
 values:
 
-* `g:nerdtree_tabs_open_on_gui_startup` (default: `1`)  
+* `g:nerdtree_tabs_open_on_gui_startup` (default: `1`)
   Open NERDTree on gvim/macvim startup
 
-* `g:nerdtree_tabs_open_on_console_startup` (default: `0`)  
+* `g:nerdtree_tabs_open_on_console_startup` (default: `0`)
   Open NERDTree on console vim startup
 
-* `g:nerdtree_tabs_no_startup_for_diff` (default: `1`)  
+* `g:nerdtree_tabs_no_startup_for_diff` (default: `1`)
   Do not open NERDTree if vim starts in diff mode
 
-* `g:nerdtree_tabs_smart_startup_focus` (default: `1`)  
+* `g:nerdtree_tabs_smart_startup_focus` (default: `1`)
   On startup, focus NERDTree if opening a directory, focus file if opening
   a file. (When set to `2`, always focus file window after startup).
 
-* `g:nerdtree_tabs_open_on_new_tab` (default: `1`)  
+* `g:nerdtree_tabs_open_on_new_tab` (default: `1`)
   Open NERDTree on new tab creation (if NERDTree was globally opened by
   :NERDTreeTabsToggle)
 
-* `g:nerdtree_tabs_meaningful_tab_names` (default: `1`)  
+* `g:nerdtree_tabs_meaningful_tab_names` (default: `1`)
   Unfocus NERDTree when leaving a tab for descriptive tab names
 
-* `g:nerdtree_tabs_autoclose` (default: `1`)  
+* `g:nerdtree_tabs_autoclose` (default: `1`)
   Close current tab if there is only one window in it and it's NERDTree
 
-* `g:nerdtree_tabs_synchronize_view` (default: `1`)  
+* `g:nerdtree_tabs_synchronize_view` (default: `1`)
   Synchronize view of all NERDTree windows (scroll and cursor position)
 
-* `g:nerdtree_tabs_synchronize_focus` (default: `1`)  
+* `g:nerdtree_tabs_synchronize_focus` (default: `1`)
   Synchronize focus when switching windows (focus NERDTree after tab switch
   if and only if it was focused before tab switch)
 
-* `g:nerdtree_tabs_focus_on_files` (default: `0`)  
+* `g:nerdtree_tabs_focus_on_files` (default: `0`)
   When switching into a tab, make sure that focus is on the file window,
   not in the NERDTree window. (Note that this can get annoying if you use
   NERDTree's feature "open in new tab silently", as you will lose focus on the
   NERDTree.)
 
-* `g:nerdtree_tabs_startup_cd` (default: `1`)  
+* `g:nerdtree_tabs_startup_cd` (default: `1`)
   When given a directory name as a command line parameter when launching Vim,
   `:cd` into it.
+
+* `g:nerdtree_tabs_autofind` (default: `0`)
+  Automatically find and select currently opened file in NERDTree.
 
 ### Example
 

--- a/nerdtree_plugin/vim-nerdtree-tabs.vim
+++ b/nerdtree_plugin/vim-nerdtree-tabs.vim
@@ -59,6 +59,11 @@ endif
 if !exists('g:nerdtree_tabs_startup_cd')
   let g:nerdtree_tabs_startup_cd = 1
 endif
+
+" automatically find and select currently opened file
+if !exists('g:nerdtree_tabs_autofind')
+  let g:nerdtree_tabs_autofind = 0
+endif
 "
 " }}}
 " === plugin mappings === {{{
@@ -66,11 +71,12 @@ endif
 noremap <silent> <script> <Plug>NERDTreeTabsOpen     :call <SID>NERDTreeOpenAllTabs()
 noremap <silent> <script> <Plug>NERDTreeTabsClose    :call <SID>NERDTreeCloseAllTabs()
 noremap <silent> <script> <Plug>NERDTreeTabsToggle   :call <SID>NERDTreeToggleAllTabs()
+noremap <silent> <script> <Plug>NERDTreeTabsFind     :call <SID>NERDTreeFindFile()
 noremap <silent> <script> <Plug>NERDTreeMirrorOpen   :call <SID>NERDTreeMirrorOrCreate()
 noremap <silent> <script> <Plug>NERDTreeMirrorToggle :call <SID>NERDTreeMirrorToggle()
 noremap <silent> <script> <Plug>NERDTreeSteppedOpen  :call <SID>NERDTreeSteppedOpen()
 noremap <silent> <script> <Plug>NERDTreeSteppedClose :call <SID>NERDTreeSteppedClose()
-noremap <silent> <script> <Plug>NERDTreeFocusToggle :call <SID>NERDTreeFocusToggle()
+noremap <silent> <script> <Plug>NERDTreeFocusToggle  :call <SID>NERDTreeFocusToggle()
 "
 " }}}
 " === plugin commands === {{{
@@ -78,6 +84,7 @@ noremap <silent> <script> <Plug>NERDTreeFocusToggle :call <SID>NERDTreeFocusTogg
 command! NERDTreeTabsOpen     call <SID>NERDTreeOpenAllTabs()
 command! NERDTreeTabsClose    call <SID>NERDTreeCloseAllTabs()
 command! NERDTreeTabsToggle   call <SID>NERDTreeToggleAllTabs()
+command! NERDTreeTabsFind     call <SID>NERDTreeFindFile()
 command! NERDTreeMirrorOpen   call <SID>NERDTreeMirrorOrCreate()
 command! NERDTreeMirrorToggle call <SID>NERDTreeMirrorToggle()
 command! NERDTreeSteppedOpen  call <SID>NERDTreeSteppedOpen()
@@ -204,7 +211,7 @@ endfun
 " }}}
 " s:NERDTreeFocusToggle() {{{
 "
-" focus the NERDTree view or creates it if in a file, 
+" focus the NERDTree view or creates it if in a file,
 " or unfocus NERDTree view if in NERDTree
 fun! s:NERDTreeFocusToggle()
   let s:disable_handlers_for_tabdo = 1
@@ -400,6 +407,15 @@ fun! s:RestoreNERDTreeViewIfPossible()
 endfun
 
 " }}}
+" s:NERDTreeFindFile() {{{
+"
+fun! s:NERDTreeFindFile()
+  if s:IsNERDTreeOpenInCurrentTab()
+    silent NERDTreeFind
+  endif
+endfun
+
+" }}}
 "
 " === NERDTree view manipulation (scroll and cursor positions) === }}}
 "
@@ -437,6 +453,7 @@ fun! s:LoadPlugin()
     autocmd WinEnter * call <SID>WinEnterHandler()
     autocmd WinLeave * call <SID>WinLeaveHandler()
     autocmd BufWinEnter * call <SID>BufWinEnterHandler()
+    autocmd BufRead * call <SID>BufReadHandler()
   augroup END
 
   let g:nerdtree_tabs_loaded = 1
@@ -566,6 +583,20 @@ fun! s:BufWinEnterHandler()
     if !g:nerdtree_tabs_focus_on_files
       call s:NERDTreeRestoreFocus()
     endif
+  endif
+endfun
+
+" }}}
+" s:BufReadHandler() {{{
+"
+" BufRead event gets triggered after a new buffer has been
+" successfully read from file.
+"
+fun! s:BufReadHandler()
+  " Refresh NERDTree to show currently opened file
+  if g:nerdtree_tabs_autofind
+    call s:NERDTreeFindFile()
+    call s:NERDTreeUnfocus()
   endif
 endfun
 


### PR DESCRIPTION
This commit does the following:
- It adds a function `NERDTreeTabsFind` to show currently opened file in NERDTree,
- It adds a variable `g:nerdtree_tabs_autofind` to automatically show file while reading new buffers.

Also, it might be a solution to issue #30 
