### PR TITLE
Enable nesting for the WinEnter autocommand

### DIFF
--- a/nerdtree_plugin/vim-nerdtree-tabs.vim
+++ b/nerdtree_plugin/vim-nerdtree-tabs.vim
@@ -452,7 +452,9 @@ fun! s:LoadPlugin()
     autocmd VimEnter * call <SID>VimEnterHandler()
     autocmd TabEnter * call <SID>TabEnterHandler()
     autocmd TabLeave * call <SID>TabLeaveHandler()
-    autocmd WinEnter * call <SID>WinEnterHandler()
+    " We enable nesting for this autocommand (see :h autocmd-nested) so that
+    " exiting Vim when NERDTree is the last window triggers the VimLeave event.
+    autocmd WinEnter * nested call <SID>WinEnterHandler()
     autocmd WinLeave * call <SID>WinLeaveHandler()
     autocmd BufWinEnter * call <SID>BufWinEnterHandler()
     autocmd BufRead * call <SID>BufReadHandler()


### PR DESCRIPTION
The `WinEnter` autocommand calls the `s:CloseIfOnlyNerdTreeLeft` function that exits Vim if NERDTree is the last window. Since this is done during an autocommand and [nesting is disabled by default for autocommands](http://vimdoc.sourceforge.net/htmldoc/autocmd.html#autocmd-nested), this will not trigger the `VimLeave` event which is an issue when other plugins rely on this event (for instance [YouCompleteMe](https://github.com/Valloric)).

Fixes #76.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/jistr/vim-nerdtree-tabs/81)
<!-- Reviewable:end -->
