### PR TITLE
Fix NERDTreeFindFile only opens if the file exists

### DIFF
--- a/nerdtree_plugin/vim-nerdtree-tabs.vim
+++ b/nerdtree_plugin/vim-nerdtree-tabs.vim
@@ -416,7 +416,7 @@ endfun
 " s:NERDTreeFindFile() {{{
 "
 fun! s:NERDTreeFindFile()
-  if s:IsNERDTreeOpenInCurrentTab()
+  if s:IsNERDTreeOpenInCurrentTab() && bufname('%') != ''
     silent NERDTreeFind
   endif
 endfun


### PR DESCRIPTION
- Check if there's open file when finding it.
- This especially fixes the error caused by running vim without opening a file then opening NERDTree when `g:nerdtree_tabs_autofind = 1` is set.