### PR TITLE
After auto-finding newly open buffer, do not move cursor to NERDTree

### DIFF
--- a/nerdtree_plugin/vim-nerdtree-tabs.vim
+++ b/nerdtree_plugin/vim-nerdtree-tabs.vim
@@ -254,12 +254,7 @@ fun! s:NERDTreeUnfocus()
   " back to this tab
   let t:NERDTreeTabLastWindow = winnr()
   if s:IsCurrentWindowNERDTree()
-    let l:winNum = s:NextNormalWindow()
-    if l:winNum != -1
-      exec l:winNum.'wincmd w'
-    else
-      wincmd w
-    endif
+    wincmd p
   endif
 endfun
 

--- a/nerdtree_plugin/vim-nerdtree-tabs.vim
+++ b/nerdtree_plugin/vim-nerdtree-tabs.vim
@@ -83,15 +83,15 @@ noremap <silent> <script> <Plug>NERDTreeFocusToggle  :call <SID>NERDTreeFocusTog
 " }}}
 " === plugin commands === {{{
 "
-command! NERDTreeTabsOpen     call <SID>NERDTreeOpenAllTabs()
-command! NERDTreeTabsClose    call <SID>NERDTreeCloseAllTabs()
-command! NERDTreeTabsToggle   call <SID>NERDTreeToggleAllTabs()
-command! NERDTreeTabsFind     call <SID>NERDTreeFindFile()
-command! NERDTreeMirrorOpen   call <SID>NERDTreeMirrorOrCreate()
-command! NERDTreeMirrorToggle call <SID>NERDTreeMirrorToggle()
-command! NERDTreeSteppedOpen  call <SID>NERDTreeSteppedOpen()
-command! NERDTreeSteppedClose call <SID>NERDTreeSteppedClose()
-command! NERDTreeFocusToggle  call <SID>NERDTreeFocusToggle()
+command! -bar NERDTreeTabsOpen     call <SID>NERDTreeOpenAllTabs()
+command! -bar NERDTreeTabsClose    call <SID>NERDTreeCloseAllTabs()
+command! -bar NERDTreeTabsToggle   call <SID>NERDTreeToggleAllTabs()
+command! -bar NERDTreeTabsFind     call <SID>NERDTreeFindFile()
+command! -bar NERDTreeMirrorOpen   call <SID>NERDTreeMirrorOrCreate()
+command! -bar NERDTreeMirrorToggle call <SID>NERDTreeMirrorToggle()
+command! -bar NERDTreeSteppedOpen  call <SID>NERDTreeSteppedOpen()
+command! -bar NERDTreeSteppedClose call <SID>NERDTreeSteppedClose()
+command! -bar NERDTreeFocusToggle  call <SID>NERDTreeFocusToggle()
 "
 " }}}
 " === plugin functions === {{{


### PR DESCRIPTION
I found the auto-find feature very useful when using `fzf` in `vim`. However, it's slightly annoying that the cursor moves to the NERDTree split, which prevents me from immediately editing the buffer I just openned.

I see that the cursor movement behavior comes from `NERDTreeFind`; this PR retains the cursor position via `wincmd p`, without having to modify `NERDTreeFind`.